### PR TITLE
Add ability to overwrite the architecture used when installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ Check out the [asdf](https://github.com/asdf-vm/asdf) readme for instructions.
 ```
 asdf plugin-add terragrunt https://github.com/ohmer/asdf-terragrunt
 ```
+
+### Environment Variable Options
+
+- `ASDF_TERRAGRUNT_OVERWRITE_ARCH`: force the plugin to use a specified processor architecture rather than the
+  automatically detected value. Useful, for example, for allowing users on M1 Macs to install `amd64` binaries when
+  there's no `arm64` binary available.

--- a/bin/install
+++ b/bin/install
@@ -19,9 +19,12 @@ install() {
   local platform
   [ "Linux" = "$(uname)" ] && platform="linux" || platform="darwin"
 
+  OVERWRITE_ARCH=${ASDF_TERRAGRUNT_OVERWRITE_ARCH:-"false"}
   local arch
   machine=$(uname -m)
-  if [[ $machine == "arm64" ]] || [[ $machine == "aarch64" ]]; then
+  if [[ $OVERWRITE_ARCH != "false" ]]; then
+    arch="$OVERWRITE_ARCH"
+  elif [[ $machine == "arm64" ]] || [[ $machine == "aarch64" ]]; then
     arch="arm64"
   elif [[ $machine == *"386"* ]]; then
     arch="386"


### PR DESCRIPTION
This uses a similar environment variable override supported by [asdf-hashicorp](https://github.com/asdf-community/asdf-hashicorp) for overriding the target architecture used to download the binary, which is useful when installing older versions of `terragrunt` that did not publish `darwin/arm64` binaries.